### PR TITLE
Add CI based on Github Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build
+      run:  make
+
+  build-aarch64:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build
+      uses: uraimo/run-on-arch-action@v2
+      with:
+        arch: aarch64
+        distro: ubuntu20.04
+        githubToken: ${{ github.token }}
+        dockerRunArgs: |
+          --volume "${PWD}:/psmc"
+        install: |
+          apt-get update -q -y
+          apt-get install -q -y make gcc libz-dev
+        run: |
+          cd /psmc
+          make


### PR DESCRIPTION
Builds the project on Linux x86_64 and aarch64.

CI results could be seen on my fork: https://github.com/martin-g/psmc/actions/runs/3045227268/jobs/4906526874

Related-to: #44 